### PR TITLE
issue: aga_randomness

### DIFF
--- a/src/racetime_bot/mod.rs
+++ b/src/racetime_bot/mod.rs
@@ -1820,9 +1820,10 @@ impl GlobalState {
             let world_state = if crosskeys_options.inverted_ok { "inverted" } else { "open" };
             let pseudoboots = if crosskeys_options.pb_ok { 1 } else { 0 };
             let skullwoods = if crosskeys_options.zw_ok { "followlinked" } else { "original" };
+            let aga_randomness = if crosskeys_options.all_dungeons_ok { "false" } else { "none" }; 
 
             let crosskeys_settings = AlttprDoorRandoSetting {
-                aga_randomness: None,
+                aga_randomness: aga_randomness,
                 accessibility: "locations",
                 bigkeyshuffle: DungeonShuffleVal::Bool(true),
                 boss_shuffle: None,

--- a/src/racetime_bot/mod.rs
+++ b/src/racetime_bot/mod.rs
@@ -1820,7 +1820,7 @@ impl GlobalState {
             let world_state = if crosskeys_options.inverted_ok { "inverted" } else { "open" };
             let pseudoboots = if crosskeys_options.pb_ok { 1 } else { 0 };
             let skullwoods = if crosskeys_options.zw_ok { "followlinked" } else { "original" };
-            let aga_randomness = if crosskeys_options.all_dungeons_ok { "false" } else { "none" }; 
+            let aga_randomness = if crosskeys_options.all_dungeons_ok { "false" } else { None }; 
 
             let crosskeys_settings = AlttprDoorRandoSetting {
                 aga_randomness: aga_randomness,


### PR DESCRIPTION
Related to this issue: https://github.com/TreZc0/hyrule-town-hall/issues/17

For players with All Dungeons as a setting, they've wanted 0 blue balls and 0 Ganon Warps. Setting aga_randomness to False instead of None for AD reflects this.
